### PR TITLE
[Backend] - feat: [#34] 이벤트 목록 조회 api

### DIFF
--- a/backend/src/main/java/team15/airbnb/category/application/CategoryService.java
+++ b/backend/src/main/java/team15/airbnb/category/application/CategoryService.java
@@ -1,13 +1,15 @@
 package team15.airbnb.category.application;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import team15.airbnb.category.infrastructure.EventRepository;
 import team15.airbnb.category.infrastructure.RegionRepository;
+import team15.airbnb.category.presentation.dto.EventListResponse;
 import team15.airbnb.category.presentation.dto.RegionDistanceDto;
 import team15.airbnb.category.presentation.dto.RegionResponse;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Transactional
 @Service
@@ -17,10 +19,11 @@ public class CategoryService {
     private final int MINUTES = 60;
     private final int AVG_VELOCITY = 75;
     private final RegionRepository regionRepository;
+    private final EventRepository eventRepository;
 
-
-    public CategoryService(RegionRepository regionRepository) {
+    public CategoryService(RegionRepository regionRepository, EventRepository eventRepository) {
         this.regionRepository = regionRepository;
+        this.eventRepository = eventRepository;
     }
 
     public List<RegionResponse> searchRegions(double longitude, double latitude) {
@@ -28,6 +31,12 @@ public class CategoryService {
         return regions.stream()
                 .map(r -> RegionResponse.convertFrom(r, calcDurationTime(r.getDistance())))
                 .collect(Collectors.toList());
+    }
+
+
+    public EventListResponse searchEvents() {
+        return new EventListResponse(eventRepository.findAll());
+
     }
 
     private int calcDurationTime(double distance) {

--- a/backend/src/main/java/team15/airbnb/category/domain/Event.java
+++ b/backend/src/main/java/team15/airbnb/category/domain/Event.java
@@ -6,20 +6,25 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import team15.airbnb.common.domain.BaseEntity;
 
+@Getter
+@NoArgsConstructor
 @Entity
 public class Event extends BaseEntity {
 
-	@Id
-	@Column(name = "event_id")
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
+    @Id
+    @Column(name = "event_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
-	@NotNull
-	@Column(name = "event_name")
-	private String name;
+    @NotNull
+    @Column(name = "event_name")
+    private String name;
 
-	@Column(name = "event_image")
-	private String image;
+    @Column(name = "event_image")
+    private String image;
 }

--- a/backend/src/main/java/team15/airbnb/category/infrastructure/EventRepository.java
+++ b/backend/src/main/java/team15/airbnb/category/infrastructure/EventRepository.java
@@ -1,0 +1,19 @@
+package team15.airbnb.category.infrastructure;
+
+import org.springframework.stereotype.Repository;
+import team15.airbnb.category.presentation.dto.EventResponse;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import java.util.List;
+
+@Repository
+public class EventRepository {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    public List<EventResponse> findAll() {
+        return em.createQuery("select new team15.airbnb.category.presentation.dto.EventResponse(e.id, e.name, e.image) from Event e", EventResponse.class).getResultList();
+    }
+}

--- a/backend/src/main/java/team15/airbnb/category/infrastructure/RegionRepository.java
+++ b/backend/src/main/java/team15/airbnb/category/infrastructure/RegionRepository.java
@@ -32,7 +32,7 @@ public class RegionRepository {
         JpaResultMapper mapper = new JpaResultMapper();
         String point = String.format("'POINT(%s %s)'", latitude, longitude);
 
-        Query q = em.createNativeQuery("select r.region_id as categoryId, r.region_name as categoryName, r.region_image as imageUrl, " +
+        Query q = em.createNativeQuery("select r.region_id as categoryId, r.region_name as categoryName, r.region_image as mainImage, " +
                 "st_distance_sphere(ST_GeomFromText(" + point + "), r.coordinate) as distance from region r");
 
         return mapper.list(q, RegionDistanceDto.class);

--- a/backend/src/main/java/team15/airbnb/category/presentation/controller/CategoryController.java
+++ b/backend/src/main/java/team15/airbnb/category/presentation/controller/CategoryController.java
@@ -1,13 +1,13 @@
 package team15.airbnb.category.presentation.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.locationtech.jts.io.ParseException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import team15.airbnb.category.application.CategoryService;
+import team15.airbnb.category.presentation.dto.EventListResponse;
 import team15.airbnb.category.presentation.dto.RegionListResponse;
 
 @RequiredArgsConstructor
@@ -25,4 +25,8 @@ public class CategoryController {
         return ResponseEntity.ok().body(new RegionListResponse(categoryService.searchRegions(longitude, latitude)));
     }
 
+    @GetMapping("/events")
+    public ResponseEntity<EventListResponse> searchEventList() {
+        return ResponseEntity.ok().body(categoryService.searchEvents());
+    }
 }

--- a/backend/src/main/java/team15/airbnb/category/presentation/dto/EventListResponse.java
+++ b/backend/src/main/java/team15/airbnb/category/presentation/dto/EventListResponse.java
@@ -1,0 +1,18 @@
+package team15.airbnb.category.presentation.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class EventListResponse {
+
+    public EventListResponse(List<EventResponse> events) {
+        this.events = events;
+    }
+
+    private List<EventResponse> events = new ArrayList<>();
+}

--- a/backend/src/main/java/team15/airbnb/category/presentation/dto/EventResponse.java
+++ b/backend/src/main/java/team15/airbnb/category/presentation/dto/EventResponse.java
@@ -1,0 +1,24 @@
+package team15.airbnb.category.presentation.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import team15.airbnb.category.domain.Event;
+
+@Getter
+@NoArgsConstructor
+public class EventResponse {
+
+    private Long categoryId;
+    private String categoryName;
+    private String mainImage;
+
+    public EventResponse(Long categoryId, String categoryName, String mainImage) {
+        this.categoryId = categoryId;
+        this.categoryName = categoryName;
+        this.mainImage = mainImage;
+    }
+
+    public static EventResponse convertFrom(Event event) {
+        return new EventResponse(event.getId(), event.getName(), event.getImage());
+    }
+}

--- a/backend/src/main/java/team15/airbnb/category/presentation/dto/RegionDistanceDto.java
+++ b/backend/src/main/java/team15/airbnb/category/presentation/dto/RegionDistanceDto.java
@@ -12,13 +12,13 @@ public class RegionDistanceDto {
 
     private BigInteger categoryId;
     private String categoryName;
-    private String imageUrl;
+    private String mainImage;
     private double distance;
 
-    public RegionDistanceDto(BigInteger categoryId, String categoryName, String imageUrl, double distance) {
+    public RegionDistanceDto(BigInteger categoryId, String categoryName, String mainImage, double distance) {
         this.categoryId = categoryId;
         this.categoryName = City.valueOf(categoryName).getName();
-        this.imageUrl = imageUrl;
+        this.mainImage = mainImage;
         this.distance = distance;
     }
 }

--- a/backend/src/main/java/team15/airbnb/category/presentation/dto/RegionResponse.java
+++ b/backend/src/main/java/team15/airbnb/category/presentation/dto/RegionResponse.java
@@ -12,18 +12,18 @@ public class RegionResponse {
 
     private BigInteger categoryId;
     private String categoryName;
-    private String imageUrl;
+    private String mainImage;
     private int durationTime;
 
-    private RegionResponse(BigInteger categoryId, String categoryName, String imageUrl, int durationTime) {
+    private RegionResponse(BigInteger categoryId, String categoryName, String mainImage, int durationTime) {
         this.categoryId = categoryId;
         this.categoryName = categoryName;
-        this.imageUrl = imageUrl;
+        this.mainImage = mainImage;
         this.durationTime = durationTime;
     }
 
     public static RegionResponse convertFrom(RegionDistanceDto dto, int durationTime) {
-        return new RegionResponse(dto.getCategoryId(), dto.getCategoryName(), dto.getImageUrl(), durationTime);
+        return new RegionResponse(dto.getCategoryId(), dto.getCategoryName(), dto.getMainImage(), durationTime);
     }
 
 }

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -20,6 +20,23 @@ values ('DAEJUN', 'http://seoul', ST_GeomFromText('POINT(126.7660 36.3504)'));
 insert into region(region_name, region_image, coordinate)
 values ('BUCHEON', 'http://seoul', ST_GeomFromText('POINT(126.9780 37.5665)'));
 
+insert into event(event_name, event_image, is_deleted, created_at, last_modified_at)
+values ('봄에 가기 좋은 숙소',
+        'https://user-images.githubusercontent.com/79504043/169987721-839ddb22-7aff-49f2-bad0-76ffc0f8f249.png', false,
+        '2022-06-04 16:37:00', '2022-06-04 16:37:00');
+insert into event(event_name, event_image, is_deleted, created_at, last_modified_at)
+values ('여름에 가기 좋은 숙소',
+        'https://user-images.githubusercontent.com/79504043/169987721-839ddb22-7aff-49f2-bad0-76ffc0f8f249.png', false,
+        '2022-06-04 16:37:00', '2022-06-04 16:37:00');
+insert into event(event_name, event_image, is_deleted, created_at, last_modified_at)
+values ('가을에 가기 좋은 숙소',
+        'https://user-images.githubusercontent.com/79504043/169987721-839ddb22-7aff-49f2-bad0-76ffc0f8f249.png', false,
+        '2022-06-04 16:37:00', '2022-06-04 16:37:00');
+insert into event(event_name, event_image, is_deleted, created_at, last_modified_at)
+values ('겨울에 가기 좋은 숙소',
+        'https://user-images.githubusercontent.com/79504043/169987721-839ddb22-7aff-49f2-bad0-76ffc0f8f249.png', false,
+        '2022-06-04 16:37:00', '2022-06-04 16:37:00');
+
 
 insert into accommodation(accommodation_name, accommodation_description, accommodation_type,
                           price, main_image, cleaning_fee, service_fee, accommodation_tax,
@@ -81,3 +98,5 @@ values(4, 'https://user-images.githubusercontent.com/57708971/171983097-bb00919f
 insert into accommodation_image(accommodation_id,url, is_deleted, created_at, last_modified_at)
 values(4, 'https://user-images.githubusercontent.com/57708971/171983178-4f65a1b8-f9d1-437b-8104-c638262ed9c5.png',
        false, '2022-06-04 00:00:01', '2022-06-04 00:00:01');
+
+


### PR DESCRIPTION
## 🤷‍♂️ Description

<!-- 구현하고자 하는 기능에 대해 작성해 주세요. -->

이벤트 목록 조회 api

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] Event Repository 및 Dto 클래스 작성
- [x] Controller, Service에 기능 추가

기존 api는 전체 목록을 한번에 조회하는 api였는데
- 전체 목록 조회
- 지역 목록 조회 
모두 사용자의 위치 정보를 함께 넘겨받게 되어야한다.
api 형태가 너무 겹치고 굳이 한번에 모든 정보를 줄 필요가 있나 싶었고, 지역과 이벤트를 분리하는게 좋겠다고 생각되어 이벤트만 따로 받아오는 api를 일단 구현 후 pr날림!

## 📷 Screenshots

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->



<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->
